### PR TITLE
add onSanitizeOutputLine prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ https://webscopeio.github.io/react-console/
 | inputClassName         | string | className for `input` |
 | history                | string[] | history array |
 | onAddHistoryItem       | (entry: string) => void | callback called when a new history entry is created |
+| onSanitizeOutputLine   | (line: string) => string | callback called before a new output line is inserted to DOM |
 
 \*_are mandatory_
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,7 @@ export type ReactConsoleProps = {
   // history props
   history?: string[],
   onAddHistoryItem?: (entry: string) => void,
+  onSanitizeOutputLine?: (line: string) => string,
 }
 
 type ReactConsoleState = {
@@ -185,6 +186,16 @@ export default class ReactConsole extends React.Component<ReactConsoleProps, Rea
       autoFocus,
     } = this.props;
 
+    const sanitizeOutputLine = (line: string): string => {
+      const {onSanitizeOutputLine} = this.props;
+
+      if (typeof onSanitizeOutputLine === 'function') {
+        return onSanitizeOutputLine(line)
+      }
+
+      return line
+    }
+
     return (
       <div
         className={classnames(styles.wrapper, wrapperClassName)}
@@ -196,13 +207,15 @@ export default class ReactConsole extends React.Component<ReactConsoleProps, Rea
         ref={ref => this.wrapperRef = ref}
       >
         <div>
-          {this.state.output.map((line, key) =>
-            <pre
-              key={key}
-              className={classnames(styles.line, lineClassName)}
-              style={lineStyle}
-              dangerouslySetInnerHTML={{__html: line}}
-            />
+          {this.state.output
+            .map(line => sanitizeOutputLine(line))
+            .map((line, key) =>
+              <pre
+                key={key}
+                className={classnames(styles.line, lineClassName)}
+                style={lineStyle}
+                dangerouslySetInnerHTML={{__html: line}}
+              />
           )}
         </div>
         <form


### PR DESCRIPTION
mandatory for fixing XSS issues.

ps. to see the XSS issue just enter this line in the console example: `<img src="xxx" onError="alert('you are screwed')">`

pss. i didn't want to fix the XSS right there by escaping the html because it might be what the users of react-console want (maybe add rich elements?). with a callback, it's just up to the user to do his own logic.
